### PR TITLE
authentication response & local embedded redis

### DIFF
--- a/src/main/java/sshj/sshj/component/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/sshj/sshj/component/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,4 @@
+package sshj.sshj.component;
+
+public class JwtAuthenticationEntryPoint {
+}

--- a/src/main/java/sshj/sshj/configuration/EmbeddedRedisConfig.java
+++ b/src/main/java/sshj/sshj/configuration/EmbeddedRedisConfig.java
@@ -1,0 +1,4 @@
+package sshj.sshj.configuration;
+
+public class EmbeddedRedisConfig {
+}


### PR DESCRIPTION
유효하지 않은 토큰 보내면 401 보냄
local로 실행 시 embedded redis로 실행. 따로 레디스 설치 할 필요 없음. 로컬에 깔려있으면 중지시키고 프로그램 돌려야 에러 안남